### PR TITLE
Issues corrected :: Large text fields; handle transactions delivered to CDA out of sequence across timestamps;

### DIFF
--- a/src/main/scala/gw/cda/api/outputwriter/JdbcOutputWriter.scala
+++ b/src/main/scala/gw/cda/api/outputwriter/JdbcOutputWriter.scala
@@ -578,10 +578,10 @@ private[outputwriter] class JdbcOutputWriter(override val outputPath: String, ov
       // These are the OOTB columns we have found so far.
       val tableNameNoSchema = tableName.substring(tableName.indexOf(".") + 1)
       (tableNameNoSchema, fieldName) match {
-        case ("cc_outboundrecord", "\"content\"") |
-             ("cc_contactorigvalue", "\"origvalue\"") |
-             ("pc_diagratingworksheet", "\"diagnosticcapture\"") |
-             ("cc_note", "\"body\"") => largeStringDataType
+        case ("cc_outboundrecord", "content") |
+             ("cc_contactorigvalue", "origval as ue") |
+             ("pc_diagratingworksheet", "diagnosticcapture") |
+             ("cc_note", "body") => largeStringDataType
         case _                       => stringDataType
       }
     }
@@ -620,7 +620,7 @@ private[outputwriter] class JdbcOutputWriter(override val outputPath: String, ov
         ddlPrimaryKey = ddlPrimaryKey + "(\"id\")"
       }
       else {
-        ddlPrimaryKey = ddlPrimaryKey + "(\"id\", \"gwcbi___seqval_hex\")"
+        ddlPrimaryKey = ddlPrimaryKey + "(\"id\", \"gwcbi___seqval_hex\", \"gwcbi___operation\")"
       }
       log.info(s"$jdbcWriteType - $ddlPrimaryKey")
       stmt.execute(ddlPrimaryKey)


### PR DESCRIPTION
**Issue correction 1)** Large text field (ones we know about ahead of time) were not getting created in the database with the correct data type because of some escape characters in the column names. The escape characters have been removed and the creation of those columns during a load has been tested across all three supported database platforms.

**Issue correction 2)** We found out the hard way that while all transactions are guaranteed to arrive in CDA, they are not guaranteed to arrive in the correct order. We ran across edge cases where out of sequence transactions are loaded across multiple timestamps, meaning we could be overwriting a newer record with an older one. The database UPDATE statements have been changed to check the "gwcbi___seqval_hex" column value and restrict updates only to rows where that value is greater than the one in place for any given "id" value.

**### KNOWN ISSUE IDENTIFIED:** In the Merged data load, if the initial INSERT and the first UPDATE following that INSERT arrive out of sequence and across timestamp folders (all it takes is 1 microsecond delay), the UPDATE will come in first, and not get applied, and during the following load the INSERT will get applied properly. The initial UPDATE to the record will never get applied, and the record will be out of date until the next UPDATE comes across for the given "id" value and makes the data current.
Uncertain how to correct this in the Merged data load - we have all the data in the Raw data load, so may need some reconciliations to handle this issue outside the Client application.
Possibly need to make changes to the client to track when an UPDATE doesn't get applied because there is no record to UPDATE, meaning the INSERT hasn't happened yet, and hold on to the record to apply later. Will continue to review.