### PR TITLE
Ensure the java.io.tmpdir actually ends with a '/' character

### DIFF
--- a/src/test/scala/com/guidewire/cda/SavepointsProcessorTest.scala
+++ b/src/test/scala/com/guidewire/cda/SavepointsProcessorTest.scala
@@ -13,7 +13,7 @@ import scala.io.Source
 @RunWith(classOf[JUnitRunner])
 class SavepointsProcessorTest extends CDAClientTestSpec {
 
-  private val tempDir = System.getProperty("java.io.tmpdir") //This will be an OS specific temp dir, with a "/" at the end
+  private val tempDir = System.getProperty("java.io.tmpdir").replaceAll("/?$", "/") //This will be an OS specific temp dir, with a "/" at the end
   private val testSavepointsPath: String = s"${tempDir}testsavepoints"
   private val testSavepointsDirectory = new File(testSavepointsPath)
   private val testSavepointsPathWithExistingFile: String = "src/test/resources"

--- a/src/test/scala/gw/cda/api/outputwriter/LocalOutputWriterTest.scala
+++ b/src/test/scala/gw/cda/api/outputwriter/LocalOutputWriterTest.scala
@@ -20,7 +20,7 @@ import scala.io.Source
 
 class LocalOutputWriterTest extends CDAClientTestSpec {
 
-  private val tempDir = System.getProperty("java.io.tmpdir") //This will be an OS specific temp dir, with a "/" at the end
+  private val tempDir = System.getProperty("java.io.tmpdir").replaceAll("/?$", "/") //This will be an OS specific temp dir, with a "/" at the end
   private val testWriterPath = s"${tempDir}cda-client-test"
   private val testSchemaFingerprint = "schemaFingerprint"
   private val testDirectory = new File(testWriterPath)


### PR DESCRIPTION
This fixes an issue with some Operating Systems where `System.getProperty("java.io.tmpdir")` does not return a path with a trailing separator.

More specifically, I ran into this issue on Gentoo Linux where `System.getProperty("java.io.tmpdir")` returns "/tmp".