### PR TITLE
temp fix in issue https://github.com/Guidewire/cda-client/issues/20

### DIFF
--- a/src/main/scala/com/guidewire/cda/TableReader.scala
+++ b/src/main/scala/com/guidewire/cda/TableReader.scala
@@ -412,7 +412,7 @@ class TableReader(clientConfig: ClientConfig) {
            |for being later than the manifest last successful write timestamp $manifestTimestampForTable""".stripMargin.replaceAll("\n", " ")
       )
     }
-    includeFolder
+    (includeFolder && S3ClientSupplier.s3Client.doesObjectExist(tableTimestampSubfolderInfo.timestampSubfolderURI.getBucket,tableTimestampSubfolderInfo.timestampSubfolderURI.getKey + "_SUCCESS"))
   }
 
   /** Function to read each timestamp subfolder's files into a Spark DataFrame. Results will be stored in


### PR DESCRIPTION
I encounter the same issue stated in https://github.com/Guidewire/cda-client/issues/20.  I used the file _SUCCESS to identify whether the timestamp folder has a parquet file.